### PR TITLE
Truncate long urls with elipses in bookmark cards

### DIFF
--- a/style.css
+++ b/style.css
@@ -166,6 +166,9 @@ a {
   display: block;
   padding-top: 18px;
   padding-bottom: 25px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 a:hover {


### PR DESCRIPTION
Just added css styling so that if a url is longer than the card width, it is truncated with an elipsis. This is dynamic and works as you resize the screen/cards. 