### PR TITLE
Fix card height on mobile view

### DIFF
--- a/responsive.css
+++ b/responsive.css
@@ -7,7 +7,6 @@
 
   .bookmark-card {
     max-width: 100%;
-    height: 378px;
   }
 
   #bookmark-list {


### PR DESCRIPTION
Removed the height from the .bookmark-card in the responsive css. Not sure why we had a set height on that card, so let me know if you see a reason to add it back in. If so, we'll just want to make it a consistent height with the cards in desktop view.  