### PR TITLE
Fix clear unread bookmarks button toggle

### DIFF
--- a/responsive.css
+++ b/responsive.css
@@ -7,7 +7,6 @@
 
   .bookmark-card {
     max-width: 100%;
-    height: 378px;
   }
 
   #bookmark-list {

--- a/script.js
+++ b/script.js
@@ -100,6 +100,7 @@ function getReadCount() {
   var totalReadBookmarks = $('.read').length;
 
   $(totalReadCounter).text(totalReadBookmarks);
+  toggleClearReadBookmarksButton()
 };
 
 function getUnreadCount() {


### PR DESCRIPTION
Added the toggleClearReadBookmarksButton function to the retReadCount function so that the button checks for a toggle every time the read count changes (should now work on all cases of read count changing from deleting cards, toggling read/unread, or clearing all unread)